### PR TITLE
Fixes an issue that prevents list from being unable to save after re-ordering

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -16,6 +16,9 @@ var templates = {
 
 var debounceSave = _.debounce(save, 500);
 
+// Indicate dragging state
+var dragging = false;
+
 enableSwipeSave();
 checkPanelLength();
 
@@ -30,6 +33,7 @@ setTimeout(function() {
     cursor: '-webkit-grabbing; -moz-grabbing;',
     axis: 'y',
     start: function(event, ui) {
+      dragging = true;
       var itemId = $(ui.item).data('id');
       var itemProvider = _.find(linkPromises, function(provider) {
         return provider.id === itemId;
@@ -66,6 +70,8 @@ setTimeout(function() {
         return sortedIds.indexOf(item.id);
       });
       $('.panel').not(ui.item).removeClass('faded');
+
+      dragging = false;
       
       save(false, true);
     },
@@ -136,6 +142,10 @@ $(".tab-content")
 
   })
   .on('show.bs.collapse', '.panel-collapse', function() {
+    if (dragging) {
+      return;
+    }
+
     // Get item ID / Get provider / Get item
     var itemID = $(this).parents('.panel').data('id');
     var itemProvider = _.find(linkPromises, function(provider) {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4281
## Description
We added an additional variable dragging to prevent the creation of an additional provider while dragging an item that caused an error and did not allow saving changes due to the error.
## Backward compatibility
This change is fully backward compatible.