### PR TITLE
changed version of widget (list no images) 4281

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "List (no images)",
   "package": "com.fliplet.simple-list",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:list"],
   "html_tag": "div",


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4281
## Description
changed version of widget (list no images) for 1.0.0.
## Backward compatibility
This change is fully backward compatible.