### PR TITLE
Placeholder in IE now will display as placeholder not a default value for production version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ﻿.idea/*
+.history

--- a/interface.html
+++ b/interface.html
@@ -142,7 +142,7 @@
               <label for="list-item-desc-\{{id}}">Description</label>
             </div>
             <div class="col-sm-8">
-              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" placeholder="Enter description" rows="3"></textarea>
+              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" rows="3"></textarea>
             </div>
           </div>
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -260,6 +260,7 @@ function addListItem(data) {
   var $newPanel = $(templates.panel(data));
   $accordionContainer.append($newPanel);
 
+  $newPanel.find('.form-control.list-item-desc').attr('placeholder', 'Enter description');
   $newPanel.find('.form-control:eq(0)').select();
   $('form.form-horizontal').stop().animate({
     scrollTop: $('.tab-content').height()


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5060

## Description
Placeholder in IE now will display as a placeholder, not a default value

## Backward compatibility

This change is fully backward compatible.

## Notes
Same as in this [PR](https://github.com/Fliplet/fliplet-widget-list/pull/34) so it worked on the production.