### PR TITLE
Title list is centered vertically

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -17,7 +17,7 @@
 .list.list-default ul > li {
   list-style: none;
   border-bottom: 1px solid rgba(51, 51, 51, 0.2);
-  padding: 10px;
+  padding: 12px 10px 8px 10px;
   position: relative;
   -webkit-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5367

## Description
Changed paddings. Unable to do it with flex.

## Screenshots/screencasts
<img width="388" alt="title demo" src="https://user-images.githubusercontent.com/52824207/70064592-78223c80-15f2-11ea-9929-ccddf3def8e0.png">

## Backward compatibility
This change is fully backward compatible.