### PR TITLE
Title list is centered vertically

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -17,7 +17,7 @@
 .list.list-default ul > li {
   list-style: none;
   border-bottom: 1px solid rgba(51, 51, 51, 0.2);
-  padding: 10px;
+  padding: 12px 10px 8px 10px;
   position: relative;
   -webkit-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#5367

## Description
Changed paddings. 

## Screenshots/screencasts
<img width="388" alt="no-images" src="https://user-images.githubusercontent.com/52824207/71986757-a91b1000-3235-11ea-8a4a-9827728b08c1.png">

## Backward compatibility
This change is fully backward compatible.