### PR TITLE
Show description for IE11 users

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -270,7 +270,7 @@ function addListItem(data) {
 }
 
 function checkPanelLength() {
-  if ($('.panel').length) {
+  if (data.items.length) {
     $('#list-items').removeClass('list-items-empty');
   } else {
     $('#list-items').addClass('list-items-empty');


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5391

## Description
Show description for IE11 users

## Screenshots/screencasts
![5391](https://user-images.githubusercontent.com/53430352/72069916-ea242a80-32f0-11ea-92e1-e7cc89dcc262.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
The reason why in the MS IE11 description wasn't shown is because of the `#document-fragment` part witch doesn't support MS IE11
Chrome
![image](https://user-images.githubusercontent.com/53430352/72070578-9581af00-32f2-11ea-9a30-32731e719791.png)
MS IE11
![image](https://user-images.githubusercontent.com/53430352/72070644-ba762200-32f2-11ea-9734-166c21e05caa.png)

