### PR TITLE
OD-334 [Fix] Remove list item link arrow on version 1.0.0

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -46,6 +46,10 @@
   cursor: pointer;
 }
 
+.list.list-default ul > li .list-icon {
+  display: none;
+}
+
 .list.list-default ul > li.linked .list-icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-334 https://weboo.atlassian.net/browse/OD-334
## Description
Removed list item link arrow on version 1.0.0
## Screenshots/screencasts
https://monosnap.com/file/bwyXziGiFf4vcrrHZqXc6DLL2aRDWp
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii
## Notes
We need to deploy it to staging for testing with version 1.0.0. Currently we can't do it on development.